### PR TITLE
Add basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Mirror Mind
+
+This project provides a simple interface for experimenting with character and scenario prompts. It uses [Gradio](https://gradio.app/) and other Python libraries.
+
+## Requirements
+
+- **Python**: 3.10 or newer
+
+## Installation
+
+Install the required dependencies with `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the application
+
+Start the application by executing `app.py`:
+
+```bash
+python app.py
+```
+
+The script launches a local Gradio server on port `7861`. Ensure that LM Studio is running on `http://localhost:1234` as printed when the app starts.
+
+## Running the tests
+
+The test suite uses `pytest`. After installing the dependencies, run:
+
+```bash
+pytest
+```
+


### PR DESCRIPTION
## Summary
- document required Python version (3.10+)
- show how to install dependencies
- add instructions to run `app.py`
- add instructions to run the tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6841b578827c832f8921d9907b277112